### PR TITLE
Add: custom cookieName support, followRedirect, additional playground pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,13 @@ export default defineNuxtConfig({
     // redirects: {
     //   login: '/login',
     //   success: '/',
-    //   home: '/'
+    //   home: '/',
+    //   followRedirect: true //automatically redirects unauthed users back to prefious page after authenticating
     // },
     // registerComponents: true,
     // augmentContext: true,
-  }
+    // cookieName: 'hanko'
+  },
 })
 ```
 

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -1,14 +1,10 @@
 <template>
   <nav>
-    <NuxtLink to="/">
-      Go home
-    </NuxtLink>
-    <NuxtLink to="/about">
-      About page
-    </NuxtLink>
-    <NuxtLink to="/login">
-      Log in page
-    </NuxtLink>
+    <NuxtLink to="/"> Go home </NuxtLink>
+    <NuxtLink to="/login"> Log in page ⛔️👤 </NuxtLink>
+    <NuxtLink to="/user"> User Page 🔐 </NuxtLink>
+    <NuxtLink to="/protected"> Protected page 🔐 </NuxtLink>
+    <NuxtLink to="/about"> About page </NuxtLink>
   </nav>
   <NuxtPage />
 </template>

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -2,13 +2,24 @@ export default defineNuxtConfig({
   modules: ['nuxt-hanko'],
   hanko: {
     // You need to provide the Hanko API URL in order for it to work
-    apiURL: ''
+    apiURL: '',
+    redirects: {
+      login: '/login', // this is the default
+      home: '/', // this is the default
+      success: '/user', // this is a custom redirect
+      followRedirect: true, // this can be set to false to always redirect to the success page
+    },
   },
   // Make the app look a bit nicer
   app: {
     head: {
       bodyAttrs: { class: 'container' },
-      link: [{ rel: 'stylesheet', href: 'https://cdn.jsdelivr.net/npm/@picocss/pico@1/css/pico.min.css' }]
-    }
+      link: [
+        {
+          rel: 'stylesheet',
+          href: 'https://cdn.jsdelivr.net/npm/@picocss/pico@1/css/pico.min.css',
+        },
+      ],
+    },
   },
 })

--- a/playground/pages/about.vue
+++ b/playground/pages/about.vue
@@ -1,9 +1,9 @@
-
 <template>
   <main>
     <h1>About</h1>
     <p>
-      Some about page content.
+      This page is accesible to both logged in and logged out users. No middleware is defined for
+      this page.
     </p>
   </main>
 </template>

--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -1,32 +1,11 @@
-<script setup lang="ts">
-definePageMeta({
-  middleware: ['hanko-logged-in']
-})
-
-const hanko = useHanko()
-function logout() {
-  hanko!.user.logout()
-}
-
-const result = ref()
-
-async function tryAuthenticatedRequest() {
-  result.value = null
-  result.value = await $fetch('/api/test')
-}
-</script>
+<script setup lang="ts"></script>
 
 <template>
   <main>
-    <h1>
-      Logged in!
-    </h1>
-    <button @click="logout">
-      Log me out
-    </button>
-    <button @click="tryAuthenticatedRequest">
-      Try auth request
-    </button>
-    <pre>{{ result }}</pre>
+    <h1>Home</h1>
+    <p>
+      This page is accesible to both logged in and logged out users. No middleware is defined for
+      this page. Use the navigation above to navigate to other pages.
+    </p>
   </main>
 </template>

--- a/playground/pages/login.vue
+++ b/playground/pages/login.vue
@@ -1,13 +1,23 @@
-
-<template>
-  <main>
-    <h1>Log in</h1>
-    <hanko-auth />
-  </main>
-</template>
-
 <script setup lang="ts">
 definePageMeta({
   middleware: ['hanko-logged-out']
 })
+const redirectPath = ref<string | null>(null)
+redirectPath.value = useRoute().query.redirect as string | null
 </script>
+
+<template>
+  <main>
+    <h1>Log in</h1>
+    <p>
+      Only logged out users can see this page<pre>definePageMeta({
+  middleware: ['hanko-logged-out'],
+})</pre>
+    </p>
+    <p v-if="$route.query.redirect">
+      You were redirected here from {{ $route.query.redirect }}, once you login, you'll be sent back automatically!
+    </p>
+    <hanko-auth />
+  </main>
+</template>
+

--- a/playground/pages/protected.vue
+++ b/playground/pages/protected.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+definePageMeta({
+  middleware: ['hanko-logged-in'],
+})
+const hanko = useHanko()
+function logout() {
+  hanko!.user.logout()
+}
+</script>
+<template>
+  <div>
+    <h1>Protected Page</h1>
+    <p>
+      Only logged in users can see this page<pre>definePageMeta({
+  middleware: ['hanko-logged-in'],
+})</pre>
+    </p>
+    <button @click="logout">
+      Log me out
+    </button>
+  </div>
+</template>

--- a/playground/pages/user.vue
+++ b/playground/pages/user.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+definePageMeta({
+  middleware: ['hanko-logged-in'],
+})
+
+const hanko = useHanko()
+function logout() {
+  hanko!.user.logout()
+}
+
+const result = ref()
+
+async function tryAuthenticatedRequest() {
+  result.value = null
+  result.value = await $fetch('/api/test')
+}
+</script>
+
+<template>
+  <main>
+    <h1>You are logged in!</h1>
+    <p>
+      Only logged in users can see this page<pre>definePageMeta({
+  middleware: ['hanko-logged-in'],
+})</pre>
+    </p>
+    <button @click="logout">
+      Log me out
+    </button>
+    <button @click="tryAuthenticatedRequest">
+      Try an auth request
+    </button>
+    <pre>{{ result }}</pre>
+  </main>
+</template>

--- a/src/module.ts
+++ b/src/module.ts
@@ -16,10 +16,12 @@ export interface ModuleOptions {
   apiURL?: string
   registerComponents?: boolean
   augmentContext?: boolean
+  cookieName?: string
   redirects?: {
     login?: string
     home?: string
     success?: string
+    followRedirect?: boolean
   }
 }
 
@@ -32,10 +34,12 @@ export default defineNuxtModule<ModuleOptions>({
     apiURL: '',
     registerComponents: true,
     augmentContext: true,
+    cookieName: 'hanko',
     redirects: {
       login: '/login',
       home: '/',
       success: '/',
+      followRedirect: true,
     },
   },
   setup(options, nuxt) {
@@ -48,6 +52,7 @@ export default defineNuxtModule<ModuleOptions>({
     nuxt.options.runtimeConfig.public = defu(nuxt.options.runtimeConfig.public, {
       hanko: {
         apiURL: options.apiURL,
+        cookieName: options.cookieName,
       },
     })
 

--- a/src/runtime/middleware/logged-in.ts
+++ b/src/runtime/middleware/logged-in.ts
@@ -14,7 +14,7 @@ export default defineNuxtRouteMiddleware(async to => {
     const event = useRequestEvent()
 
     if (!event.context.hanko?.sub && to.path !== redirects.login) {
-      return navigateTo(redirects.login)
+      return navigateTo(`${redirects.login}?redirect=${to.path}`)
     }
     return
   }
@@ -22,11 +22,11 @@ export default defineNuxtRouteMiddleware(async to => {
   const hanko = useHanko()!
 
   if (!(await hanko.user.getCurrent().catch(() => null)) && to.path !== redirects.login) {
-    return navigateTo(redirects.login)
+    return navigateTo(`${redirects.login}?redirect=${to.path}`)
   }
 
   const removeHankoHook = hanko.onUserLoggedOut(() => {
-    navigateTo(redirects.login)
+    return navigateTo(`${redirects.login}?redirect=${to.path}`)
   })
   const removeRouterHook = useRouter().beforeEach(() => {
     removeHankoHook()

--- a/src/runtime/middleware/logged-out.ts
+++ b/src/runtime/middleware/logged-out.ts
@@ -26,7 +26,10 @@ export default defineNuxtRouteMiddleware(async to => {
   }
 
   const removeHankoHook = hanko.onAuthFlowCompleted(() => {
-    navigateTo(redirects.success)
+    if (!redirects.followRedirect || !to.query.redirect) {
+      navigateTo(redirects.success)
+    }
+    navigateTo(to.query.redirect as string)
   })
   const removeRouterHook = useRouter().beforeEach(() => {
     removeHankoHook()

--- a/src/runtime/server/utils/index.ts
+++ b/src/runtime/server/utils/index.ts
@@ -3,10 +3,12 @@ import { createRemoteJWKSet, jwtVerify } from 'jose'
 import { useRuntimeConfig } from '#imports'
 
 export async function verifyHankoEvent(event: H3Event) {
-  const jwksHost = useRuntimeConfig().public.hanko.apiURL
+  const hankoConfig = useRuntimeConfig().public.hanko
+  const jwksHost = hankoConfig.apiURL
   const JWKS = createRemoteJWKSet(new URL(`${jwksHost}/.well-known/jwks.json`))
 
-  const jwt = getHeader(event, 'authorization')?.split(' ').pop() || getCookie(event, 'hanko')
+  const cookieName = hankoConfig.cookieName
+  const jwt = getHeader(event, 'authorization')?.split(' ').pop() || getCookie(event, cookieName)
 
   if (!jwt) {
     throw createError({


### PR DESCRIPTION
**Support custom cookie name**
Hanko will add custom cookie names soon, https://github.com/teamhanko/hanko/issues/243
New module key `cookieName` has been added to module options and in serverside utils

**Add followRedirect**
Added module option `followRedirect` (default `true`)
When a user authenticates after hitting the logged-in middleware, they'll be redirected back to the original page they accessed.
Can be set to `false` in module config, redirect will be to `redirects.success` value

**Playground Update**
Added additional `protected` page, moved auth'd page to `user` and set index to blank page.
There was some confusion with the user page being index, but it also being the redirect for home.
Added additional texts to pages to say why/how page is visible