### PR TITLE
fix: add missing return for logged-out middleware

### DIFF
--- a/src/runtime/middleware/logged-out.ts
+++ b/src/runtime/middleware/logged-out.ts
@@ -27,8 +27,7 @@ export default defineNuxtRouteMiddleware(async to => {
 
   const removeHankoHook = hanko.onAuthFlowCompleted(() => {
     if (!redirects.followRedirect || !to.query.redirect) {
-      navigateTo(redirects.success)
-      return
+      return navigateTo(redirects.success)
     }
     navigateTo(to.query.redirect as string)
   })

--- a/src/runtime/middleware/logged-out.ts
+++ b/src/runtime/middleware/logged-out.ts
@@ -28,6 +28,7 @@ export default defineNuxtRouteMiddleware(async to => {
   const removeHankoHook = hanko.onAuthFlowCompleted(() => {
     if (!redirects.followRedirect || !to.query.redirect) {
       navigateTo(redirects.success)
+      return
     }
     navigateTo(to.query.redirect as string)
   })

--- a/src/runtime/middleware/logged-out.ts
+++ b/src/runtime/middleware/logged-out.ts
@@ -27,7 +27,8 @@ export default defineNuxtRouteMiddleware(async to => {
 
   const removeHankoHook = hanko.onAuthFlowCompleted(() => {
     if (!redirects.followRedirect || !to.query.redirect) {
-      return navigateTo(redirects.success)
+      navigateTo(redirects.success)
+      return
     }
     navigateTo(to.query.redirect as string)
   })


### PR DESCRIPTION
Redirect on Auth middleware was missing a return;
Leading to double navigateTo() and ignoring configured redirects.success